### PR TITLE
Add Dockerfile without pre-vendoring

### DIFF
--- a/novendor.Dockerfile
+++ b/novendor.Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.12 AS build
+
+WORKDIR /go/src/github.com/benthosdev/benthos-lab/
+COPY . /go/src/github.com/benthosdev/benthos-lab/
+
+ENV GO111MODULE on
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./benthos-lab ./server/benthos-lab \
+  && GOOS=js GOARCH=wasm go build -ldflags="-s -w -X main.Version=`cat ./benthos_version`" -o ./client/wasm/benthos-lab.wasm ./client/wasm/benthos-lab.go \
+  && useradd -u 10001 benthos
+
+FROM busybox AS package
+
+LABEL maintainer="Ashley Jeffs <ash@jeffail.uk>"
+
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /go/src/github.com/benthosdev/benthos-lab/benthos-lab .
+COPY --from=build /go/src/github.com/benthosdev/benthos-lab/client /var/www
+
+USER benthos
+
+EXPOSE 8080
+
+ENTRYPOINT ["/benthos-lab"]
+
+CMD ["--www", "/var/www"]


### PR DESCRIPTION
Hi there,

I added a novendor.Dockerfile, that can be used without doing `go mod vendor` first.

It allows users to build benthos-lab directly from the repository without even cloning it, like this:
```sh
docker build -t benthos-lab https://github.com/ilyaglow/benthos-lab.git#novendor-dockerfile -f novendor.Dockerfile
```

Also, I reduced the number of `RUN` command layers and removed the `WORKDIR` command in the package stage, which is unnecessary since it's a default working directory. 