### PR TITLE
Add Dockerfile for a bleeding edge version of Benthos

### DIFF
--- a/bleeding-edge.Dockerfile
+++ b/bleeding-edge.Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.12 AS build
+
+COPY . /benthos-lab/
+WORKDIR /benthos-lab
+
+ENV GO111MODULE=on
+
+RUN go get github.com/Jeffail/benthos/v3@master \
+  && CGO_ENABLED=0 GOOS=linux go build -o ./benthos-lab ./server/benthos-lab \
+  && GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o ./client/wasm/benthos-lab.wasm ./client/wasm/benthos-lab.go \
+  && useradd -u 10001 benthos
+
+FROM busybox AS package
+
+LABEL maintainer="Ashley Jeffs <ash@jeffail.uk>"
+
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /benthos-lab/benthos-lab .
+COPY --from=build /benthos-lab/client /var/www
+
+USER benthos
+
+EXPOSE 8080
+
+ENTRYPOINT ["/benthos-lab"]
+
+CMD ["--www", "/var/www"]


### PR DESCRIPTION
Hey there,

Benthos is being actively developed at a fast pace (you rock!) and sometimes it's useful to play with all the latest features, so I've made this.

Users should keep in mind that this image should be always built with `--no-cache` switch and of course these builds should not be considered as reproducible.

Cheers!